### PR TITLE
fix: no default value for locale, set default to en_US

### DIFF
--- a/android/src/main/java/bz/rxla/flutter/speechrecognition/SpeechRecognitionPlugin.java
+++ b/android/src/main/java/bz/rxla/flutter/speechrecognition/SpeechRecognitionPlugin.java
@@ -113,7 +113,6 @@ public class SpeechRecognitionPlugin implements MethodCallHandler, RecognitionLi
     @Override
     public void onEndOfSpeech() {
         Log.d(LOG_TAG, "onEndOfSpeech");
-        speechChannel.invokeMethod("speech.onRecognitionComplete", transcription);
     }
 
     @Override

--- a/lib/speech_recognition.dart
+++ b/lib/speech_recognition.dart
@@ -32,8 +32,10 @@ class SpeechRecognition {
   Future activate() => _channel.invokeMethod("speech.activate");
 
   /// start listening
-  Future listen({String locale}) =>
-      _channel.invokeMethod("speech.listen", locale);
+  Future listen({String locale = "en_US"}) {
+    assert(locale != null);
+    _channel.invokeMethod("speech.listen", locale);
+  }
 
   Future cancel() => _channel.invokeMethod("speech.cancel");
 


### PR DESCRIPTION
Set locale value to en_US by default and make sure it's not null. This will prevent ugly null pointer exceptions thrown by Android when locale is null.

Invoking onSpeechComplete from onEndOfSpeech will cause it to be invoked twice since onResults is anyway going to invoke onSpeechComplete.