### PR TITLE
Fix non-default locale recognition on Android

### DIFF
--- a/android/src/main/java/bz/rxla/flutter/speechrecognition/SpeechRecognitionPlugin.java
+++ b/android/src/main/java/bz/rxla/flutter/speechrecognition/SpeechRecognitionPlugin.java
@@ -64,7 +64,7 @@ public class SpeechRecognitionPlugin implements MethodCallHandler, RecognitionLi
                 result.success(true);
                 break;
             case "speech.listen":
-                recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, getLocale(call.arguments.toString()));
+                recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, getAndroidLocaleCode(call.arguments.toString()));
                 speech.startListening(recognizerIntent);
                 result.success(true);
                 break;
@@ -87,9 +87,8 @@ public class SpeechRecognitionPlugin implements MethodCallHandler, RecognitionLi
         }
     }
 
-    private Locale getLocale(String code) {
-        String[] localeParts = code.split("_");
-        return new Locale(localeParts[0], localeParts[1]);
+    private String getAndroidLocaleCode(String code) {
+        return code.replace("_", "-");
     }
 
     @Override


### PR DESCRIPTION
According to [documenation](https://developer.android.com/reference/android/speech/RecognizerIntent) `EXTRA_LANGUAGE` value should be 
> IETF language tag (as defined by BCP 47), for example "en-US"

So I just replaced `Locale` with the correct format and that fixed #2 for me. I tested those changes with Android 6 and 8.