### PR TITLE
Fix: getConfiguration().locale field was deprecated in API level 24

### DIFF
--- a/android/src/main/java/bz/rxla/flutter/speechrecognition/SpeechRecognitionPlugin.java
+++ b/android/src/main/java/bz/rxla/flutter/speechrecognition/SpeechRecognitionPlugin.java
@@ -7,6 +7,7 @@ import android.speech.RecognitionListener;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
 import android.util.Log;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -58,7 +59,12 @@ public class SpeechRecognitionPlugin implements MethodCallHandler, RecognitionLi
             case "speech.activate":
                 // FIXME => Dummy activation verification : we assume that speech recognition permission
                 // is declared in the manifest and accepted during installation ( AndroidSDK 21- )
-                Locale locale = activity.getResources().getConfiguration().locale;
+                Locale locale;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                    locale = activity.getResources().getConfiguration().getLocales().get(0);
+                } else {
+                    locale = activity.getResources().getConfiguration().locale;
+                }
                 Log.d(LOG_TAG, "Current Locale : " + locale.toString());
                 speechChannel.invokeMethod("speech.onCurrentLocale", locale.toString());
                 result.success(true);


### PR DESCRIPTION
[Configuration.locale](https://developer.android.com/reference/android/content/res/Configuration.html#locale)

> **This field was deprecated in API level 24.**
Do not set or read this directly. Use [**getLocales()**](https://developer.android.com/reference/android/content/res/Configuration.html#getLocales()) and setLocales(android.os.LocaleList). If only the primary locale is needed, **getLocales().get(0)** is now the preferred accessor.