### PR TITLE
[Android] Always return local language or English problem fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+- fix android chinese locale error
+- fix exmaple code(main.dart:155)
+
 ## 0.3.0
 
 - dart 2.0+ & Flutter 0.11.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.1
 
-- fix android chinese locale error
+- fix android - Correcting problems that are not returned in the language you have called(SpeechRecognitionPlugin:68)
 - fix exmaple code(main.dart:155)
 
 ## 0.3.0

--- a/android/src/main/java/bz/rxla/flutter/speechrecognition/SpeechRecognitionPlugin.java
+++ b/android/src/main/java/bz/rxla/flutter/speechrecognition/SpeechRecognitionPlugin.java
@@ -64,7 +64,8 @@ public class SpeechRecognitionPlugin implements MethodCallHandler, RecognitionLi
                 result.success(true);
                 break;
             case "speech.listen":
-                recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, getLocale(call.arguments.toString()));
+                Log.d(LOG_TAG, "Listen Start, Language is "+call.arguments.toString());
+                recognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, call.arguments.toString());
                 speech.startListening(recognizerIntent);
                 result.success(true);
                 break;
@@ -85,11 +86,6 @@ public class SpeechRecognitionPlugin implements MethodCallHandler, RecognitionLi
                 result.notImplemented();
                 break;
         }
-    }
-
-    private Locale getLocale(String code) {
-        String[] localeParts = code.split("_");
-        return new Locale(localeParts[0], localeParts[1]);
     }
 
     @Override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -116,7 +116,7 @@ class _MyAppState extends State<MyApp> {
       .toList();
 
   void _selectLangHandler(Language lang) {
-    setState(() => {selectedLang = lang});
+    setState(() => selectedLang = lang);
   }
 
   Widget _buildButton({String label, VoidCallback onPressed}) => new Padding(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,11 +6,13 @@ void main() {
 }
 
 const languages = const [
-  const Language('Francais', 'fr_FR'),
   const Language('English', 'en_US'),
+  const Language('Francais', 'fr_FR'),
   const Language('Pусский', 'ru_RU'),
   const Language('Italiano', 'it_IT'),
   const Language('Español', 'es_ES'),
+  const Language('Simplified Chinese', 'cmn-Hans-CN'),
+  const Language('Japanese', 'ja_JP'),
 ];
 
 class Language {
@@ -114,7 +116,7 @@ class _MyAppState extends State<MyApp> {
       .toList();
 
   void _selectLangHandler(Language lang) {
-    setState(() => selectedLang = lang);
+    setState(() => {selectedLang = lang});
   }
 
   Widget _buildButton({String label, VoidCallback onPressed}) => new Padding(
@@ -128,9 +130,8 @@ class _MyAppState extends State<MyApp> {
         ),
       ));
 
-  void start() => _speech
-      .listen(locale: selectedLang.code)
-      .then((result) => print('_MyAppState.start => result $result'));
+  void start() => _speech.listen(locale: selectedLang.code).then((result) =>
+      print('_MyAppState.start => (' + selectedLang.code + ')result $result'));
 
   void cancel() =>
       _speech.cancel().then((result) => setState(() => _isListening = result));
@@ -152,7 +153,8 @@ class _MyAppState extends State<MyApp> {
 
   void onRecognitionResult(String text) => setState(() => transcription = text);
 
-  void onRecognitionComplete() => setState(() => _isListening = false);
+  void onRecognitionComplete(String text) =>
+      setState(() => _isListening = false);
 
   void errorHandler() => activateSpeechRecognizer();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: speech_recognition
 description: A flutter plugin to use the speech recognition on iOS and Android
-version: 0.3.0+1
+version: 0.3.1
 author: Erick Ghaumez <erick@rxla.bz>
 homepage: https://github.com/rxlabz/speech_recognition
 environment:


### PR DESCRIPTION
Nice to find your great plug-in.
If you are not satisfied with the code that I modified, please request modification:)

I tested it on my cell phone using your plug-in and found that no input other than Korean and English was returned normally.

After debugging the code, After changing the parameter to String, it was confirmed to be working properly.
(SpeechRecognitionPlugin.java:67-68)

Once you've seen it working properly in the example app, I wonder why you've added Locale. Did I use it wrong?