### PR TITLE
Fix crash when calling installTap

### DIFF
--- a/ios/Classes/SwiftSpeechRecognitionPlugin.swift
+++ b/ios/Classes/SwiftSpeechRecognitionPlugin.swift
@@ -141,13 +141,13 @@ public class SwiftSpeechRecognitionPlugin: NSObject, FlutterPlugin, SFSpeechReco
 
       if error != nil || isFinal {
         self.audioEngine.stop()
-        inputNode.removeTap(onBus: 0)
         self.recognitionRequest = nil
         self.recognitionTask = nil
       }
     }
 
     let recognitionFormat = inputNode.outputFormat(forBus: 0)
+    inputNode.removeTap(onBus: 0)
     inputNode.installTap(onBus: 0, bufferSize: 1024, format: recognitionFormat) {
       (buffer: AVAudioPCMBuffer, when: AVAudioTime) in
       self.recognitionRequest?.append(buffer)


### PR DESCRIPTION
We need to make sure removeTap is always called before installTap is called. Before this PR there was a race condition that led to installTap being called without first removing the previous installTap.

2019-04-09 14:17:55.559484-0700 Runner[33324:2600082] [avae] AVAEInternal.h:70:_AVAE_Check: required condition is false: [AVAEGraphNode.mm:851:CreateRecordingTap: (nullptr == Tap())]
2019-04-09 14:17:55.617660-0700 Runner[33324:2600082] *** Terminating app due to uncaught exception 'com.apple.coreaudio.avfaudio', reason: 'required condition is false: nullptr == Tap()'
*** First throw call stack:
(
	0   CoreFoundation                      0x00000001082166fb __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x00000001077baac5 objc_exception_throw + 48
	2   CoreFoundation                      0x0000000108216482 +[NSException raise:format:arguments:] + 98
	3   AVFAudio                            0x000000011ec51f3c _Z19AVAE_RaiseExceptionP8NSStringz + 156
	4   AVFAudio                            0x000000011ecb0937 _Z11_AVAE_CheckPKciS0_S0_b + 295
	5   AVFAudio                            0x000000011ec6dbe0 _ZN17AUGraphNodeBaseV318CreateRecordingTapEmjP13AVAudioFormatU13block_pointerFvP16AVAudioPCMBufferP11AVAudioTimeE + 116
	6   AVFAudio                            0x000000011ec4cb5a _ZN18AVAudioEngineGraph16InstallTapOnNodeEP11AVAudioNodemjP13AVAudioFormatU13block_pointerFvP16AVAudioPCMBufferP11AVAudioTimeE + 218
	7   AVFAudio                            0x000000011ecbbc85 _ZN17AVAudioEngineImpl16InstallTapOnNodeEP11AVAudioNodemjP13AVAudioFormatU13block_pointerFvP16AVAudioPCMBufferP11AVAudioTimeE + 13
	8   AVFAudio                            0x000000011ecac06c -[AVAudioNode installTapOnBus:bufferSize:format:block:] + 208
	9   speech_recognition                  0x000000010773f017 $s18speech_recognition28SwiftSpeechRecognitionPluginC5start33_5E733C6DAD67387E5EE9E83523EF0FD9LL4langySS_tKF + 1863
	10  speech_recognition                  0x000000010773e3f3 $s18speech_recognition28SwiftSpeechRecognitionPluginC05startE033_5E733C6DAD67387E5EE9E83523EF0FD9LL4lang6resultySS_yypSgXEtF + 675
	11  speech_recognition                  0x000000010773cefa $s18speech_recognition28SwiftSpeechRecognitionPluginC6handle_6resultySo17FlutterMethodCallC_yypSgctF + 1066
	12  speech_recognition                  0x000000010773d34b $s18speech_recognition28SwiftSpeechRecognitionPluginC6handle_6resultySo17FlutterMethodCallC_yypSgctFTo + 139
	13  Flutter                             0x00000001039447ba __45-[FlutterMethodChannel setMethodCallHandler:]_block_invoke + 115
	14  Flutter                             0x00000001039614ac _ZNK5shell21PlatformMessageRouter21HandlePlatformMessageEN3fml6RefPtrIN5blink15PlatformMessageEEE + 166
	15  Flutter                             0x0000000103964ff0 _ZN5shell15PlatformViewIOS21HandlePlatformMessageEN3fml6RefPtrIN5blink15PlatformMessageEEE + 38
	16  Flutter                             0x00000001039b7ca7 _ZNSt3__110__function6__funcIZN5shell5Shell29OnEngineHandlePlatformMessageEN3fml6RefPtrIN5blink15PlatformMessageEEEE4$_27NS_9allocatorIS9_EEFvvEEclEv + 57
	17  Flutter                             0x0000000103970e0e _ZN3fml15MessageLoopImpl15RunExpiredTasksEv + 522
	18  Flutter                             0x000000010397418c _ZN3fml17MessageLoopDarwin11OnTimerFireEP16__CFRunLoopTimerPS0_ + 26
	19  CoreFoundation                      0x000000010817e3e4 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
	20  CoreFoundation                      0x000000010817dff2 __CFRunLoopDoTimer + 1026
	21  CoreFoundation                      0x000000010817d85a __CFRunLoopDoTimers + 266
	22  CoreFoundation                      0x0000000108177efc __CFRunLoopRun + 2220
	23  CoreFoundation                      0x0000000108177302 CFRunLoopRunSpecific + 626
	24  GraphicsServices                    0x000000010bc6f2fe GSEventRunModal + 65
	25  UIKitCore                           0x0000000112314ba2 UIApplicationMain + 140
	26  Runner                              0x000000010092a1c8 main + 72
	27  libdyld.dylib                       0x00000001092a4541 start + 1
	28  ???                                 0x0000000000000001 0x0 + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException