### PR TITLE
Send error code to errorHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ speech.cancel();
 
 speech.stop();
 
+// Handle recognition errors
+_speech.setErrorHandler((SpeechRecognitionError e) => print('error: $e'));
+
 ```
 
 ### Recognition

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -152,7 +152,7 @@ class _MyAppState extends State<MyApp> {
 
   void onRecognitionResult(String text) => setState(() => transcription = text);
 
-  void onRecognitionComplete() => setState(() => _isListening = false);
+  void onRecognitionComplete(String text) => setState(() => _isListening = false);
 
-  void errorHandler() => activateSpeechRecognizer();
+  void errorHandler(SpeechRecognitionError error) => activateSpeechRecognizer();
 }

--- a/lib/speech_enums.dart
+++ b/lib/speech_enums.dart
@@ -1,0 +1,70 @@
+class SpeechRecognitionError {
+  const SpeechRecognitionError._(this.value);
+  factory SpeechRecognitionError.fromInt(int value) {
+    try {
+      return values[value];
+    } catch(e) {
+      return SpeechRecognitionError.unknown;
+    }
+  }
+
+  final int value;
+
+  /// Unknown error.
+  static const SpeechRecognitionError unknown = SpeechRecognitionError._(0);
+
+  /// Network operation timed out.
+  static const SpeechRecognitionError networkTimeout = SpeechRecognitionError._(1);
+
+  /// Other network related errors.
+  static const SpeechRecognitionError network = SpeechRecognitionError._(2);
+
+  /// Audio recording error.
+  static const SpeechRecognitionError recording = SpeechRecognitionError._(3);
+
+  /// Server sends error status.
+  static const SpeechRecognitionError server = SpeechRecognitionError._(4);
+
+  /// Other client side errors.
+  static const SpeechRecognitionError client = SpeechRecognitionError._(5);
+
+  /// No speech input.
+  static const SpeechRecognitionError clientTimeout = SpeechRecognitionError._(6);
+
+  /// No recognition result matched.
+  static const SpeechRecognitionError noMatch = SpeechRecognitionError._(7);
+
+  /// RecognitionService is busy.
+  static const SpeechRecognitionError busy = SpeechRecognitionError._(8);
+
+  /// Insufficient permissions.
+  static const SpeechRecognitionError noPermission = SpeechRecognitionError._(9);
+
+  static const List<SpeechRecognitionError> values = <SpeechRecognitionError>[
+    networkTimeout,
+    network,
+    recording,
+    server,
+    client,
+    clientTimeout,
+    noMatch,
+    busy,
+    noPermission,
+  ];
+
+  static const List<String> _names = <String>[
+    'unknown',
+    'networkTimeout',
+    'network',
+    'recording',
+    'server',
+    'client',
+    'clientTimeout',
+    'noMatch',
+    'busy',
+    'noPermission',
+  ];
+
+  @override
+  String toString() => 'SpeechRecognitionError.${_names[value]}';
+}

--- a/lib/speech_recognition.dart
+++ b/lib/speech_recognition.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
-
 import 'dart:ui';
 import 'package:flutter/services.dart';
 
+import 'speech_enums.dart';
+export 'speech_enums.dart';
+
 typedef void AvailabilityHandler(bool result);
 typedef void StringResultHandler(String text);
+typedef void ErrorHandler(SpeechRecognitionError error);
 
 /// the channel to control the speech recognition
 class SpeechRecognition {
@@ -27,8 +30,8 @@ class SpeechRecognition {
   VoidCallback recognitionStartedHandler;
 
   StringResultHandler recognitionCompleteHandler;
-  
-  VoidCallback errorHandler;
+
+  ErrorHandler errorHandler;
 
   /// ask for speech  recognizer permission
   Future activate() => _channel.invokeMethod("speech.activate");
@@ -62,7 +65,7 @@ class SpeechRecognition {
         recognitionCompleteHandler(call.arguments);
         break;
       case "speech.onError":
-        errorHandler();
+        errorHandler(SpeechRecognitionError.fromInt(call.arguments));
         break;
       default:
         print('Unknowm method ${call.method} ');
@@ -88,5 +91,5 @@ class SpeechRecognition {
   void setCurrentLocaleHandler(StringResultHandler handler) =>
       currentLocaleHandler = handler;
   
-  void setErrorHandler(VoidCallback handler) => errorHandler = handler;
+  void setErrorHandler(ErrorHandler handler) => errorHandler = handler;
 }


### PR DESCRIPTION
Improve error handling by exposing error code of failure to the consumer (developer). With this change it's finally possible to handle different kind of errors differently - we can distinguish whenever speech recognition failed due to timeout or some permission issue.  

Official list of error codes can be found here:
- https://developer.android.com/reference/android/speech/SpeechRecognizer.html#ERROR_AUDIO (all are mapped to enums)

```
import 'package:speech_recognition/speech_recognition.dart';

_speech = SpeechRecognition();
_speech.setErrorHandler((error) {
    if (error == SpeechRecognitionError.busy) {
        print("Recognizer is really busy");
    } else {
        print("Recognizer is not busy, but still not working");
    }
});
```