### PR TITLE
Remove the `setValue` methods

### DIFF
--- a/lib/speech_recognition.dart
+++ b/lib/speech_recognition.dart
@@ -68,25 +68,4 @@ class SpeechRecognition {
         print('Unknowm method ${call.method} ');
     }
   }
-
-  // define a method to handle availability / permission result
-  void setAvailabilityHandler(AvailabilityHandler handler) =>
-      availabilityHandler = handler;
-
-  // define a method to handle recognition result
-  void setRecognitionResultHandler(StringResultHandler handler) =>
-      recognitionResultHandler = handler;
-
-  // define a method to handle native call
-  void setRecognitionStartedHandler(VoidCallback handler) =>
-      recognitionStartedHandler = handler;
-
-  // define a method to handle native call
-  void setRecognitionCompleteHandler(StringResultHandler handler) =>
-      recognitionCompleteHandler = handler;
-
-  void setCurrentLocaleHandler(StringResultHandler handler) =>
-      currentLocaleHandler = handler;
-  
-  void setErrorHandler(VoidCallback handler) => errorHandler = handler;
 }


### PR DESCRIPTION
Dart possesses powerful [getter and setter syntax](https://dart.dev/guides/language/language-tour#getters-and-setter), this change makes the code more inline with the general dart style, and avoids pointless repetition of code that will be generated by the compiler anyway.

This change will require a modification of the major version of the plugin in order to respect the Semantic Versioning specification.